### PR TITLE
Feature/inflector fix

### DIFF
--- a/lib/carrierwave/sequel.rb
+++ b/lib/carrierwave/sequel.rb
@@ -2,6 +2,7 @@
 
 require 'sequel'
 require 'carrierwave'
+require 'active_support/inflector'
 
 module CarrierWave
   module Sequel

--- a/spec/sequel_spec.rb
+++ b/spec/sequel_spec.rb
@@ -178,4 +178,11 @@ describe CarrierWave::Sequel do
     end
 
   end
+
+  describe 'inflection' do
+    it "should inflect table names properly" do
+      class User < Sequel::Model; end
+      User.table_name.should == :users
+    end
+  end
 end


### PR DESCRIPTION
CarrierWave uses ActiveSupport's core-ext lib which in turn, overrides Sequel's Inflector class.  

Unfortunately, the way core-ext is structured, it loads the Inflector class but does not actually load any inflector rules.  As a result, Sequel cannot not pluralize or singularize table names and associations properly.  

To fix this, simply require `active_support/inflector`.  This will load the appropriate inflection rules.