### PR TITLE
Fix: mount_uploader accepts options and block

### DIFF
--- a/lib/carrierwave/sequel.rb
+++ b/lib/carrierwave/sequel.rb
@@ -7,7 +7,7 @@ module CarrierWave
   module Sequel
     include CarrierWave::Mount
 
-    def mount_uploader(column, uploader)
+    def mount_uploader(column, uploader, options={}, &block)
       raise "You need to use Sequel 3.0 or higher. Please upgrade." unless ::Sequel::Model.respond_to?(:plugin)
       super
 


### PR DESCRIPTION
This PR brings carrierwave-sequel up to date with Carrierwave's `mount_uploader` method signature, allowing options and block to be passed.
