### PR TITLE
mark record as modified when file is changed, fixes #2

### DIFF
--- a/lib/carrierwave/sequel.rb
+++ b/lib/carrierwave/sequel.rb
@@ -11,6 +11,43 @@ module CarrierWave
       raise "You need to use Sequel 3.0 or higher. Please upgrade." unless ::Sequel::Model.respond_to?(:plugin)
       super
 
+      mod = Module.new
+      include mod
+      mod.class_eval <<-RUBY, __FILE__, __LINE__+1
+        def #{column}=(new_file)
+          if !(new_file.blank? && send(:#{column}).blank?)
+            modified!
+          end
+          super
+        end
+
+        def remove_#{column}!
+          modified!
+          super
+        end
+
+        def remove_#{column}=(value)
+          modified!
+          super
+        end
+
+        # Reset cached mounter on record reload
+        def reload(*)
+          @_mounters = nil
+          super
+        end
+
+        def remote_#{column}_url=(url)
+          modified!
+          super
+        end
+
+        def remote_#{column}_urls=(url)
+          modified!
+          super
+        end
+      RUBY
+
       alias_method :read_uploader, :[]
       alias_method :write_uploader, :[]=
 

--- a/spec/sequel_spec.rb
+++ b/spec/sequel_spec.rb
@@ -106,6 +106,14 @@ describe CarrierWave::Sequel do
         @event.image.current_path.should == public_path('uploads/test.jpeg')
       end
 
+      it "should copy the file to the upload directory when a file has been assigned via Sequel::Model#update" do
+        @event.save.should be_true
+        @event.update(:image => stub_file('test.jpeg'))
+        @event.reload
+        @event.image.should be_an_instance_of(@uploader)
+        @event.image.current_path.should == public_path('uploads/test.jpeg')
+      end
+
       describe 'with validation' do
 
         before do


### PR DESCRIPTION
Based on how Carrierwave itself handles it for ActiveRecord https://github.com/carrierwaveuploader/carrierwave/blob/master/lib/carrierwave/orm/activerecord.rb#L69

Makes https://github.com/carrierwaveuploader/carrierwave-sequel/pull/8 obsolete
